### PR TITLE
Add proc.net.unix support

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,6 +40,9 @@ def test_proc_self_net_tcp(proc):
 def test_proc_self_net_udp(proc):
     assert proc.self.net.udp.keys()
 
+def test_proc_self_net_unix(proc):
+    assert proc.self.net.unix.keys()
+
 def test_proc_self_net_sockstat(proc):
     assert proc.self.net.sockstat['TCP']['alloc'] >= 0
 

--- a/tests/test_mocked_proc.py
+++ b/tests/test_mocked_proc.py
@@ -196,6 +196,10 @@ def test_first_process_net_udp(first):
     assert first.net.udp.keys()
 
 
+def test_first_process_net_unix(first):
+    assert first.net.unix.keys()
+
+
 def test_first_process_net_sockstat(first):
     assert first.net.sockstat['TCP']['alloc'] >= 0
 


### PR DESCRIPTION
Currently, proc.net.unix returns a string instead of a parsed dict.
This patch format the file like `class tcp` but the "sl" is "Num" and only available as root.
If the user is non root, the num is a key with "nonrootuser" + i.